### PR TITLE
Implement ignoring commands in inline math

### DIFF
--- a/example-files/simple.md
+++ b/example-files/simple.md
@@ -7,4 +7,4 @@ flow of a HTTP/WebSocket packet from the \gls{DN} towards the Internet.}-->
 
 * The **DELETE method** requests that the resource identified by the request <!--\gls{URI}--> be deleted <!--\cite{RFC-7252}-->.
 
-Important papers must also have important inline math, e.g. <!--$5 \times 5$--> or even <!--$x = \frac{1}{2}$-->. Escaping $-signs should also work.
+Important papers must also have important inline math, e.g. $5 \times 5$ or even $x = \frac{1}{2}$. Escaping \$-signs should also work.

--- a/main_test.go
+++ b/main_test.go
@@ -93,3 +93,22 @@ func TestLookback(t *testing.T) {
 	assert.Equal(t, "Ü", c.prev())
 	assert.Equal(t, "Falsches Ü", c.lookback(10))
 }
+
+func TestInlineMath(t *testing.T) {
+	c := getTestConverter("$5")
+	s := string(c.Convert())
+	assert.Equal(t, "$5", s)
+
+	c = getTestConverter("$\\foo")
+	s = string(c.Convert())
+	assert.Equal(t, "$<!--\\foo-->", s)
+
+	// Wrongly written $$ command, must have spaces on either side.
+	c = getTestConverter("$\\foo$")
+	s = string(c.Convert())
+	assert.Equal(t, "$<!--\\foo$-->", s)
+
+	c = getTestConverter(" $\\foo$ ")
+	s = string(c.Convert())
+	assert.Equal(t, " $\\foo$ ", s)
+}


### PR DESCRIPTION
Since MMD4 supports the inline-math syntax of LaTeX [1] merkderwn must
not escape LaTeX statements in between $ signs that match the
inline-math spec. of [1].

[1]: http://fletcher.github.io/MultiMarkdown-4/math.html